### PR TITLE
fix: pin platform: linux/amd64 for hasadna-published images

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,19 @@
 version: '2.4'
 
+# All ghcr.io/hasadna/* images are only published for linux/amd64. Pinning it
+# here (rather than relying on each user setting DOCKER_DEFAULT_PLATFORM)
+# makes pull/run work out of the box on arm64 hosts (e.g. Apple Silicon, via
+# Docker Desktop's bundled Rosetta/QEMU emulation) without forcing emulation
+# on the images below that are genuinely multi-arch (postgres, redis).
+# Native Linux arm64 hosts need QEMU binfmt registered once, e.g.:
+#   docker run --privileged --rm tonistiigi/binfmt --install all
+x-amd64-only: &amd64-only
+  platform: linux/amd64
+
 services:
 
   stride-db-init:
+    <<: *amd64-only
     image: ghcr.io/hasadna/open-bus-stride-db/open-bus-stride-db:latest
     restart: "on-failure"
     environment:
@@ -28,6 +39,7 @@ services:
       - "stride-db:/var/lib/postgresql/data"
 
   stride-etl:
+    <<: *amd64-only
     image: ghcr.io/hasadna/open-bus-stride-etl/open-bus-stride-etl:latest
     restart: "no"
     environment:
@@ -36,6 +48,7 @@ services:
       - stride-db
 
   gtfs-etl:
+    <<: *amd64-only
     image: ghcr.io/hasadna/open-bus-gtfs-etl/open-bus-gtfs-etl:latest
     restart: "no"
     environment:
@@ -47,6 +60,7 @@ services:
       - "gtfs-storage:/var/gtfs-storage"
 
   siri-requester:
+    <<: *amd64-only
     image: ghcr.io/hasadna/open-bus-siri-requester/open-bus-siri-requester:latest
     restart: unless-stopped
     environment:
@@ -63,6 +77,7 @@ services:
       - ".data/siri-requester-key:/var/siri-requester-key"
 
   siri-requester-health:
+    <<: *amd64-only
     image: ghcr.io/hasadna/open-bus-siri-requester/open-bus-siri-requester:latest
     restart: unless-stopped
     entrypoint: [open-bus-siri-requester, health-daemon-start]
@@ -72,6 +87,7 @@ services:
       - "siri-storage:/var/siri-storage"
 
   siri-requester-nginx:
+    <<: *amd64-only
     image: ghcr.io/hasadna/open-bus-siri-requester/open-bus-siri-requester-nginx:latest
     restart: unless-stopped
     ports:
@@ -84,6 +100,7 @@ services:
       - siri-requester-health
 
   siri-etl-process-new-snapshots:
+    <<: *amd64-only
     image: ghcr.io/hasadna/open-bus-siri-etl/open-bus-siri-etl:latest
     restart: unless-stopped
     command: [start-process-new-snapshots-daemon]
@@ -97,6 +114,7 @@ services:
       - stride-db
 
   stride-api:
+    <<: *amd64-only
     image: ghcr.io/hasadna/open-bus-stride-api/open-bus-stride-api:latest
     restart: unless-stopped
     ports:
@@ -117,6 +135,7 @@ services:
       - "5433:5432"
 
   airflow-webserver:
+    <<: *amd64-only
     image: ghcr.io/hasadna/open-bus-pipelines/open-bus-pipelines:latest
     restart: unless-stopped
     build: .
@@ -133,6 +152,7 @@ services:
       - redis
 
   airflow-scheduler:
+    <<: *amd64-only
     image: ghcr.io/hasadna/open-bus-pipelines/open-bus-pipelines:latest
     restart: unless-stopped
     build: .


### PR DESCRIPTION
## Problem
On arm64 hosts (e.g. Apple Silicon Macs), the very first documented setup step fails:
```
$ docker-compose pull stride-db-init
Error no matching manifest for linux/arm64/v8 in the manifest list entries: no match for platform in manifest: not found
```
I confirmed via `docker manifest inspect`/`docker buildx imagetools inspect` that every `ghcr.io/hasadna/*` image used by this compose file (stride-db, stride-etl, gtfs-etl, siri-requester, siri-etl, stride-api, open-bus-pipelines) is published **amd64-only** - there's no arm64 manifest. Docker refuses to resolve a platform for a multi-arch manifest list with no matching entry (unlike single-arch images, which just warn and let Rosetta/QEMU emulate).

By contrast, `postgres:13` and the pinned `redis:6@sha256:...` **are** genuinely multi-arch (verified the same way) - they don't need any special handling.

## Fix
Add a shared YAML anchor and pin `platform: linux/amd64` only on the services using a `ghcr.io/hasadna/*` image:
```yaml
x-amd64-only: &amd64-only
  platform: linux/amd64

services:
  stride-db-init:
    <<: *amd64-only
    image: ghcr.io/hasadna/open-bus-stride-db/open-bus-stride-db:latest
    ...
```
Applied to: `stride-db-init`, `stride-etl`, `gtfs-etl`, `siri-requester`, `siri-requester-health`, `siri-requester-nginx`, `siri-etl-process-new-snapshots`, `stride-api`, `airflow-webserver`, `airflow-scheduler`.

This works automatically for every user regardless of host architecture - no `.env`/`DOCKER_DEFAULT_PLATFORM` step to remember, and it doesn't force emulation on the two images that are already native multi-arch. On Apple Silicon and Windows this "just works" via Docker Desktop's bundled Rosetta/WSL2 emulation. Native Linux arm64 hosts need QEMU binfmt registered once (`docker run --privileged --rm tonistiigi/binfmt --install all`) - noted as a comment in the compose file.

## Alternatives considered
- `DOCKER_DEFAULT_PLATFORM=linux/amd64` via `.env`: simplest, but opt-in (every user has to know to set it) and forces unnecessary emulation on postgres/redis too.
- Publishing real multi-arch images from each repo's CI: the ideal long-term fix, but a much bigger lift across 6+ repos (at least one, gtfs-etl, has a native LevelDB dependency that would need arm64 build support verified), disproportionate to unblocking local dev.

## Test plan
- [x] Removed all cached `ghcr.io/hasadna/*` images and any `DOCKER_DEFAULT_PLATFORM` env var, then confirmed `docker-compose pull stride-db-init` succeeds using only this compose-file change (`docker-compose config` also shows `platform: linux/amd64` resolved correctly on the affected services and unaffected on `stride-db`/`airflow-db`/`redis`).
- [x] Brought up the full local stack this way (stride-db-init migrations, stride-api, processed a real SIRI snapshot end-to-end) on an Apple Silicon Mac.