### PR TITLE
docs: fix broken AGENTS.sh reference in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,8 @@
 # AI Agents Instructions
 
-If file `.AGENTS.sh.completed` exists, it means that environment was already setup for you and all relevant dependencies are installed / downloaded.
-If it does not exist, setup the environment by running the script: `bash AGENTS.sh`
+If `.venv` already exists with dependencies installed, the environment was already
+set up for you. Otherwise, follow the "Local development" section in README.md
+(`uv sync` and the steps after it) to install dependencies.
 
 Activate the virtual environment before running any commands:
 


### PR DESCRIPTION
## Problem
`AGENTS.md` instructs agents to check for `.AGENTS.sh.completed` and otherwise run `bash AGENTS.sh` to set up the environment. Neither `AGENTS.sh` nor any file matching that name exists anywhere in the repo (confirmed via `find`), so that instruction can never succeed.

## Fix
Replaced it with a pointer to the "Local development" section in README.md, which documents the actual working setup (`uv sync` and the steps after it). Left the `.venv/bin/activate` guidance as-is since it's accurate - `uv sync` creates `.venv` in the project root by default.

## Test plan
- [x] `find . -iname "AGENTS.sh"` → no matches, confirming the file genuinely doesn't exist.
- [x] Docs-only change, no functional code touched.