### PR TITLE
Prevent concurrency on scheduled tasks

### DIFF
--- a/open_bus_pipelines/dags_generator.py
+++ b/open_bus_pipelines/dags_generator.py
@@ -18,10 +18,14 @@ def dags_generator(base_url):
     )
     for dags_filename in yaml_safe_load(base_url + 'airflow.yaml').get('dag_files', []):
         for dag_config in yaml_safe_load(base_url + dags_filename):
+            max_active_runs = dag_config.get(
+                'max_active_runs', 1 if dag_config.get('schedule_interval') else None
+            )
             with DAG(
                 dag_id=dag_config['name'],
                 description=dag_config.get('description', ''),
                 schedule_interval=dag_config.get('schedule_interval', None),
+                **({} if max_active_runs is None else {'max_active_runs': max_active_runs}),
                 **dag_kwargs,
             ) as dag:
                 tasks = {}


### PR DESCRIPTION
# Descripton
Default every scheduled DAG to have `max_active_runs=1`.

## Why?
As found in https://github.com/hasadna/open-bus-stride-etl/issues/27 the add_ride_durations DAG performance is very slow.

Since the DAG is scheduled hourly, and currently every run take much longer than one hour - one possible reason for the degraded speed is multiple DAGs running in parallel and waiting for lock on the same db rows, or simply wasting effort.